### PR TITLE
README : bump required go version(1.12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ not require MCUboot.
 
 The `mcumgr` command line tool is available at:
 https://github.com/apache/mynewt-mcumgr-cli.  The command line tool requires [Go
-1.7 or later](https://golang.org/dl/).  Once Go is installed and set up on your
+1.12 or later](https://golang.org/dl/).  Once Go is installed and set up on your
 system, you can install the mcumgr CLI tool by issuing the following `go get`
 command:
 


### PR DESCRIPTION
Changed Least required go version to 1.12